### PR TITLE
Add automatic vote average calculation

### DIFF
--- a/my-new-app/server/server.ts
+++ b/my-new-app/server/server.ts
@@ -13,6 +13,7 @@ interface GameState {
     players: { [key: string]: Player };
     showVotes: boolean;
     taskName: string;
+    voteAverage: number | null;
 }
 
 const app = express();
@@ -24,10 +25,20 @@ const io = new Server(httpServer, {
     }
 });
 
+const calculateVoteAverage = (players: { [key: string]: Player }): number | null => {
+    const votes = Object.values(players)
+        .map(player => player.vote)
+        .filter((vote): vote is number => vote !== null);
+
+    if (votes.length === 0) return null;
+    return Math.round((votes.reduce((sum, vote) => sum + vote, 0) / votes.length) * 10) / 10;
+};
+
 const gameState: GameState = {
     players: {},
     showVotes: false,
-    taskName: "Implement User Authentication"
+    taskName: "Implement User Authentication",
+    voteAverage: null
 };
 
 const handlePlayerJoin = (socket: Socket, playerName: string) => {
@@ -42,17 +53,20 @@ const handlePlayerJoin = (socket: Socket, playerName: string) => {
 const handlePlayerVote = (socket: Socket, vote: number) => {
     if (gameState.players[socket.id]) {
         gameState.players[socket.id].vote = vote;
+        gameState.voteAverage = calculateVoteAverage(gameState.players);
         io.emit('gameStateUpdate', gameState);
     }
 };
 
 const handleShowVotes = () => {
     gameState.showVotes = true;
+    gameState.voteAverage = calculateVoteAverage(gameState.players);
     io.emit('gameStateUpdate', gameState);
 };
 
 const handleResetVotes = () => {
     gameState.showVotes = false;
+    gameState.voteAverage = null;
     Object.keys(gameState.players).forEach(playerId => {
         gameState.players[playerId].vote = null;
     });

--- a/my-new-app/src/ScrumPokerPage.tsx
+++ b/my-new-app/src/ScrumPokerPage.tsx
@@ -11,6 +11,7 @@ interface GameState {
     players: { [key: string]: Player };
     showVotes: boolean;
     taskName: string;
+    voteAverage: number | null;
 }
 
 const FIBONACCI_SEQUENCE = [1, 2, 3, 5, 8, 13, 21];
@@ -20,7 +21,8 @@ const ScrumPokerPage = () => {
     const [gameState, setGameState] = useState<GameState>({
         players: {},
         showVotes: false,
-        taskName: "Implement User Authentication"
+        taskName: "Implement User Authentication",
+        voteAverage: null
     });
     const [playerName, setPlayerName] = useState<string>("");
     const [isJoined, setIsJoined] = useState(false);
@@ -121,6 +123,17 @@ const ScrumPokerPage = () => {
                 marginBottom: '20px'
             }}>
                 {gameState.taskName}
+                {gameState.showVotes && gameState.voteAverage !== null && (
+                    <div style={{
+                        fontSize: '18px',
+                        marginTop: '10px',
+                        padding: '5px',
+                        backgroundColor: 'rgba(255, 255, 255, 0.1)',
+                        borderRadius: '4px'
+                    }}>
+                        Average Vote: {gameState.voteAverage}
+                    </div>
+                )}
             </div>
 
             <div style={{


### PR DESCRIPTION
This PR adds automatic vote average calculation to the Scrum Poker application:

Features:
- Automatically calculates the average of all votes
- Displays the average when votes are revealed
- Updates in real-time as votes change
- Rounds to one decimal place for clarity

Technical Changes:
- Added voteAverage to GameState interface
- Added calculateVoteAverage helper function
- Updated vote handlers to recalculate average
- Added UI component to display the average
- Maintains null state when no votes are present

Testing:
1. Join with multiple players
2. Submit various votes
3. Click Submit Votes to reveal the average
4. Verify the average updates when votes change
5. Verify the average disappears on Reset